### PR TITLE
Separate sections 21 and 34 in Hungarian translations

### DIFF
--- a/src/assets/translations/kg.json
+++ b/src/assets/translations/kg.json
@@ -2234,7 +2234,7 @@
             "sections": [
                 {
                     "id": "21",
-                    "section_title": "Jézus elhívja első tanítványait",
+                    "section_title": "Az első tanítványok",
                     "mt": [
                         null
                     ],
@@ -3393,7 +3393,7 @@
                 },
                 {
                     "id": "34",
-                    "section_title": "Jézus elhívja első tanítványait",
+                    "section_title": "A tanítványok elhívása",
                     "mt": [
                         {
                             "leading": true,

--- a/src/assets/translations/knb.json
+++ b/src/assets/translations/knb.json
@@ -2234,7 +2234,7 @@
             "sections": [
                 {
                     "id": "21",
-                    "section_title": "Jézus elhívja első tanítványait",
+                    "section_title": "Az első tanítványok",
                     "mt": [
                         null
                     ],
@@ -3393,7 +3393,7 @@
                 },
                 {
                     "id": "34",
-                    "section_title": "Jézus elhívja első tanítványait",
+                    "section_title": "A tanítványok elhívása",
                     "mt": [
                         {
                             "leading": true,

--- a/src/assets/translations/szit.json
+++ b/src/assets/translations/szit.json
@@ -2234,7 +2234,7 @@
             "sections": [
                 {
                     "id": "21",
-                    "section_title": "Jézus elhívja első tanítványait",
+                    "section_title": "Az első tanítványok",
                     "mt": [
                         null
                     ],
@@ -3393,7 +3393,7 @@
                 },
                 {
                     "id": "34",
-                    "section_title": "Jézus elhívja első tanítványait",
+                    "section_title": "A tanítványok elhívása",
                     "mt": [
                         {
                             "leading": true,


### PR DESCRIPTION
In the Hungarian translations sections 21 and 34 have identical names, but the texts are not parallel (side note: they are secondary parallels). This PR fix this situation. The new section titles are based on the NV translation.