### PR TITLE
Improve Polish section titles

### DIFF
--- a/src/assets/translations/bjw.json
+++ b/src/assets/translations/bjw.json
@@ -13761,7 +13761,7 @@
                 },
                 {
                     "id": "143",
-                    "section_title": "Różne zdania o Jezusie",
+                    "section_title": "Sąd Heroda o Jezusie",
                     "mt": [
                         {
                             "leading": true,
@@ -21000,7 +21000,7 @@
                 },
                 {
                     "id": "231",
-                    "section_title": "Moc wiary",
+                    "section_title": "„Przymnóż nam wiary!”",
                     "mt": [
                         {
                             "leading": false,
@@ -34208,7 +34208,7 @@
                 },
                 {
                     "id": "359",
-                    "section_title": "Zjawienie się Jezusa na górze. Ostatni rozkaz",
+                    "section_title": "Jezus ukazuje się uczniom na górze w Galilei. Misja apostołów",
                     "mt": [
                         {
                             "leading": false,

--- a/src/assets/translations/bt.json
+++ b/src/assets/translations/bt.json
@@ -20961,7 +20961,7 @@
                 },
                 {
                     "id": "230",
-                    "section_title": "Obowiązek przebaczenia",
+                    "section_title": "Przebaczenie żałującym za winy",
                     "mt": [
                         {
                             "leading": false,
@@ -21000,7 +21000,7 @@
                 },
                 {
                     "id": "231",
-                    "section_title": "Moc wiary",
+                    "section_title": "„Przymnóż nam wiary!”",
                     "mt": [
                         {
                             "leading": false,
@@ -25202,7 +25202,7 @@
                 },
                 {
                     "id": "272",
-                    "section_title": "Nieurodzajne drzewo figowe",
+                    "section_title": "Uschłe drzewo figowe",
                     "mt": [
                         {
                             "leading": true,
@@ -34208,7 +34208,7 @@
                 },
                 {
                     "id": "359",
-                    "section_title": "Jezus ukazuje się uczniom. Ostatni rozkaz",
+                    "section_title": "Jezus ukazuje się uczniom na górze w Galilei. Misja apostołów",
                     "mt": [
                         {
                             "leading": false,


### PR DESCRIPTION
There were some identical polish titles, which were not parallel. PR fixes this issue.