### PR TITLE
Improve sections 95 and 138

### DIFF
--- a/src/assets/translations/kg.json
+++ b/src/assets/translations/kg.json
@@ -8516,7 +8516,7 @@
                 },
                 {
                     "id": "95",
-                    "section_title": "A vérfolyásos asszony meggyógyítása. Jairus lányának feltámasztása",
+                    "section_title": "A vérfolyásos asszony meggyógyítása. Jairus leányának feltámasztása",
                     "mt": [
                         {
                             "leading": true,

--- a/src/assets/translations/knb.json
+++ b/src/assets/translations/knb.json
@@ -12888,7 +12888,7 @@
                 },
                 {
                     "id": "138",
-                    "section_title": "A vérfolyásos asszony meggyógyítása. Jairus leányának feltámasztása",
+                    "section_title": "A vérfolyásos asszony meggyógyítása. Jairus lányának feltámasztása",
                     "mt": [
                         {
                             "leading": false,

--- a/src/assets/translations/ruf.json
+++ b/src/assets/translations/ruf.json
@@ -8516,7 +8516,7 @@
                 },
                 {
                     "id": "95",
-                    "section_title": "A vérfolyásos asszony meggyógyítása. Jairus lányának feltámasztása",
+                    "section_title": "A vérfolyásos asszony meggyógyítása. Jairus leányának feltámasztása",
                     "mt": [
                         {
                             "leading": true,

--- a/src/assets/translations/szit.json
+++ b/src/assets/translations/szit.json
@@ -12888,7 +12888,7 @@
                 },
                 {
                     "id": "138",
-                    "section_title": "A vérfolyásos asszony meggyógyítása. Jairus leányának feltámasztása",
+                    "section_title": "A vérfolyásos asszony meggyógyítása. Jairus lányának feltámasztása",
                     "mt": [
                         {
                             "leading": false,


### PR DESCRIPTION
Szinopszis book uses "lány" in section 95 and "leány" in section 138.
PR fixes this problem and propose to use "leány" in KG and RUF and "lány" in SZIT and KNB.