### PR TITLE
Fix SZIT Mk6,6 and Mk6,7 in parallel texts

### DIFF
--- a/src/assets/translations/szit.json
+++ b/src/assets/translations/szit.json
@@ -3298,7 +3298,7 @@
                                     "verse": "5"
                                 },
                                 {
-                                    "text": "Maga is csodálkozott hitetlenségükön.",
+                                    "text": "Maga is csodálkozott hitetlenségükön. Végigjárta a falvakat és tanított.",
                                     "chapter": "6",
                                     "verse": "6"
                                 }
@@ -9075,7 +9075,7 @@
                             "leading": false,
                             "content": [
                                 {
-                                    "text": "Maga is csodálkozott hitetlenségükön.",
+                                    "text": "Maga is csodálkozott hitetlenségükön. Végigjárta a falvakat és tanított.",
                                     "chapter": "6",
                                     "verse": "6"
                                 }
@@ -9217,7 +9217,7 @@
                             "leading": false,
                             "content": [
                                 {
-                                    "text": "Végigjárta a falvakat és tanított. Magához hívta a tizenkettőt, és kettesével szétküldte őket, hatalmat adva nekik a tisztátalan lelkeken.",
+                                    "text": "Magához hívta a tizenkettőt, és kettesével szétküldte őket, hatalmat adva nekik a tisztátalan lelkeken.",
                                     "chapter": "6",
                                     "verse": "7"
                                 }


### PR DESCRIPTION
Based on the sources page in synopticus.org we want:
SZIT Mk6,6="Maga is csodálkozott hitetlenségükön. Végigjárta a falvakat és tanított."
SZIT Mk6,6a="Maga is csodálkozott hitetlenségükön."
SZIT Mk6,6b="Végigjárta a falvakat és tanított."
SZIT Mk6,7="Magához hívta a tizenkettőt, és kettesével szétküldte őket, hatalmat adva nekik a tisztátalan lelkeken."

PR propose to reach this goal in the parallel texts (body texts already satisfied this property)

If this PR is OK, then we could deliver a similar PR to BT!
