### PR TITLE
Review dash usages

### DIFF
--- a/src/assets/translations/eu.json
+++ b/src/assets/translations/eu.json
@@ -4022,7 +4022,7 @@
                   "verse": "5"
                 },
                 {
-                  "text": "Damit ihr aber erkennt, dass der Menschensohn die Vollmacht hat, auf der Erde Sünden zu vergeben – sagte er zu dem Gelähmten: Steh auf, nimm dein Bett und geh in dein Haus!",
+                  "text": "Damit ihr aber erkennt, dass der Menschensohn die Vollmacht hat, auf der Erde Sünden zu vergeben - sagte er zu dem Gelähmten: Steh auf, nimm dein Bett und geh in dein Haus!",
                   "chapter": "9",
                   "verse": "6"
                 },
@@ -8139,7 +8139,7 @@
                   "verse": "5"
                 },
                 {
-                  "text": "Damit ihr aber erkennt, dass der Menschensohn die Vollmacht hat, auf der Erde Sünden zu vergeben – sagte er zu dem Gelähmten: Steh auf, nimm dein Bett und geh in dein Haus!",
+                  "text": "Damit ihr aber erkennt, dass der Menschensohn die Vollmacht hat, auf der Erde Sünden zu vergeben - sagte er zu dem Gelähmten: Steh auf, nimm dein Bett und geh in dein Haus!",
                   "chapter": "9",
                   "verse": "6"
                 },


### PR DESCRIPTION
All the translations were reviewed, only one clear inconsistency was found.
On the feature branch the dash usage statistics is the following:
['-', '–', '—', '‒', '―', '−', '﹣', '⁃']
BT: [0, 119, 0, 0, 0, 0, 0, 0]
BJW: [1, 9, 0, 0, 0, 0, 0, 0]
SBLGNT: [0, 0, 25, 0, 0, 0, 0, 0]
RSP: [30, 138, 0, 0, 0, 0, 0, 0]
KNB: [112, 44, 0, 0, 0, 0, 0, 0]
NV: [4, 0, 26, 0, 0, 0, 0, 0]
SZIT: [89, 462, 0, 0, 0, 0, 0, 0]
ESV: [56, 0, 41, 0, 0, 0, 0, 0]
KG: [228, 0, 0, 0, 0, 0, 0, 0]
EU: [80, 0, 0, 0, 0, 0, 0, 0]
RUF: [116, 85, 0, 0, 0, 0, 0, 0]

