### PR TITLE
Auto line endings in prettierc

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -4,5 +4,6 @@
   "tabWidth": 2,
   "singleQuote": true,
   "printWidth": 1,
-  "trailingComma": "none"
+  "trailingComma": "none",
+  "endOfLine": "auto"
 }


### PR DESCRIPTION
The default behavior of Git on Windows is to check out files with Windows line endings (so developers on Windows work with files that have Windows line endings locally). However, when pushing to the repository, Git converts the line endings to Linux-style line endings (LF).

Husky correctly expects JSON files to use Linux line endings, but this causes large diffs when developing on Windows. For example, a simple change to a single line in a JSON file results in all line endings being converted from Windows (CRLF) to Linux (LF) line endings.

This PR proposes relaxing Husky's line-ending rule to help cross-platform development.